### PR TITLE
Injecting lp sftp username so it is not public.

### DIFF
--- a/app/jobs/lionpath_integrate_job.rb
+++ b/app/jobs/lionpath_integrate_job.rb
@@ -20,7 +20,8 @@ class LionpathIntegrateJob < ApplicationJob
       f_path
     else
       # Running bash script to grab lionpath files
-      `#{Rails.root}/bin/courses-taught.sh`
+      username = Rails.application.config_for(:activity_insight)['lp_sftp'][:username]
+      `LP_SFTP_USERNAME=#{username} #{Rails.root}/bin/courses-taught.sh`
       File.join('app', 'parsing_files', 'courses_taught.csv')
     end
   end

--- a/bin/courses-taught.sh
+++ b/bin/courses-taught.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 
+# Get username from env variable
+USERNAME=${LP_SFTP_USERNAME}
+
 # Using SFTP connection with Lionpath host to pull file names in order of most to least recent
-OUTPUT=$(sftp -P 22 -b bin/lp_sftp_newest.bat -i ~/.ssh/id_rsa_lionpath_prod uldsrdc@prod-nfs.lionpath.psu.edu)
+OUTPUT=$(sftp -P 22 -b bin/lp_sftp_newest.bat -i ~/.ssh/id_rsa_lionpath_prod $USERNAME@prod-nfs.lionpath.psu.edu)
 
 # Single out the first PE_RP_ACTIVITY_INSIGHT and pull this down as app/parsing_files/courses_taught.csv
 for x in $OUTPUT
 do
   if [[ "$x" =~ "PE_RP_ACTIVITY_INSIGHT" ]]; then
-    sftp -P 22 -r -i ~/.ssh/id_rsa_lionpath_prod uldsrdc@prod-nfs.lionpath.psu.edu:/out/$x app/parsing_files/courses_taught.csv
+    sftp -P 22 -r -i ~/.ssh/id_rsa_lionpath_prod $USERNAME@prod-nfs.lionpath.psu.edu:/out/$x app/parsing_files/courses_taught.csv
     break
   fi
 done

--- a/config/activity_insight.yml.circleci
+++ b/config/activity_insight.yml.circleci
@@ -12,6 +12,8 @@ production:
     :key: "fake"
   s3_bucket:
     api_key: "fake"
+  lp_sftp:
+    username: "fake"
 
 development:
   main:
@@ -27,6 +29,8 @@ development:
     :key: "fake"
   s3_bucket:
     api_key: "fake"
+  lp_sftp:
+    username: "fake"
 
 test:
   main:
@@ -42,3 +46,5 @@ test:
     :key: "fake"
   s3_bucket:
     api_key: "fake"
+  lp_sftp:
+    username: "fake"


### PR DESCRIPTION
We changed our username for this SFTP bucket sometime in the past year.  We share this with ETDA and never transitioned the username here — in FAMS Tools.  For a little extra security, I changed how the username is set to inject it via a config setting.