### PR TITLE
default COM integration target to production

### DIFF
--- a/lib/tasks/com_effort_data.rake
+++ b/lib/tasks/com_effort_data.rake
@@ -5,7 +5,7 @@ namespace :com_effort do
     Rails.application.eager_load!
     start = Time.now
     # Takes params hash -> params[:target] must be defined (:beta or :production)
-    params = { target: :beta }
+    params = { target: (args[:target].blank? ? :production : args[:target].to_sym) }
     puts params
     ComEffortIntegrateJob.perform_now(params, 'log/com_effort_errors.log', false)
     finish = Time.now

--- a/lib/tasks/com_quality_data.rake
+++ b/lib/tasks/com_quality_data.rake
@@ -5,7 +5,7 @@ namespace :com_quality do
     Rails.application.eager_load!
     start = Time.now
     # Takes params hash -> params[:target] must be defined (:beta or :production)
-    params = { target: :beta }
+    params = { target: (args[:target].blank? ? :production : args[:target].to_sym) }
     puts params
     ComQualityIntegrateJob.perform_now(params, 'log/com_quality_errors.log', false)
     finish = Time.now


### PR DESCRIPTION
Target was set to beta during dev work. This defaults it to production while allowing beta to be passed as an arg