### PR TITLE
fix typo

### DIFF
--- a/lib/tasks/com_effort_data.rake
+++ b/lib/tasks/com_effort_data.rake
@@ -1,7 +1,7 @@
 namespace :com_effort do
   desc 'Integrate COM Effort data.'
 
-  task :integrate, [:target] => :environment do |_task, _args|
+  task :integrate, [:target] => :environment do |_task, args|
     Rails.application.eager_load!
     start = Time.now
     # Takes params hash -> params[:target] must be defined (:beta or :production)

--- a/lib/tasks/com_quality_data.rake
+++ b/lib/tasks/com_quality_data.rake
@@ -1,7 +1,7 @@
 namespace :com_quality do
   desc 'Integrate COM Quality data.'
 
-  task :integrate, [:target] => :environment do |_task, _args|
+  task :integrate, [:target] => :environment do |_task, args|
     Rails.application.eager_load!
     start = Time.now
     # Takes params hash -> params[:target] must be defined (:beta or :production)


### PR DESCRIPTION
Workflow is failing because of the inconsistency (`_args` at the beginning of the block and then `args` later)