### PR TITLE
Parse full year our of event_date in ComEffortXmlBuilder

### DIFF
--- a/app/importers/com_data/com_effort_xml_builder.rb
+++ b/app/importers/com_data/com_effort_xml_builder.rb
@@ -18,7 +18,7 @@ class ComData::ComEffortXmlBuilder
         batch.each do |faculty|
           xml.Record('PennStateHealthUsername' => faculty.com_id) do
             faculty.com_efforts.each do |com_effort|
-              event_date = Date.strptime(com_effort.event_date, '%m/%d/%y')
+              event_date = Date.strptime(com_effort.event_date, '%m/%d/%Y')
               xml.INSTRUCT_TAUGHT do
                 xml.COURSE_YEAR_ com_effort.course_year, access: 'READ_ONLY'
                 xml.COURSE_TITLE_ com_effort.course, access: 'READ_ONLY'

--- a/spec/fixtures/ume_faculty_effort.csv
+++ b/spec/fixtures/ume_faculty_effort.csv
@@ -1,3 +1,3 @@
 FACULTY_USERNAME,FACULTY_NAME,COURSE,COURSE_YEAR,EVENT_TYPE,EVENT,EVENT_DATE,UME_CALCULATED_TEACHING_WHILE_NON_BILLING_EFFORT__HRS_
-lskywalker,Skywalker Luke,the Force,1976-1977,Lecture,FTF REQ Various Rooms 10-12 PBL - EndoRepro PBL 1402 - Thyroid,5/25/77 10:00,2
-hgranger,Granger Hermione,Potions,1997-1998,Sm Grp Facilitation,FTF REQ Various Rooms 10-12 PBL - EndoRepro PBL 1402 - Thyroid,6/26/97 9:45,7
+lskywalker,Skywalker Luke,the Force,1976-1977,Lecture,FTF REQ Various Rooms 10-12 PBL - EndoRepro PBL 1402 - Thyroid,5/25/1977 10:00,2
+hgranger,Granger Hermione,Potions,1997-1998,Sm Grp Facilitation,FTF REQ Various Rooms 10-12 PBL - EndoRepro PBL 1402 - Thyroid,6/26/1997 9:45,7

--- a/spec/importers/com_data/com_effort_populate_db_spec.rb
+++ b/spec/importers/com_data/com_effort_populate_db_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe ComData::ComEffortPopulateDb do
       expect(ComEffort.find_by(com_id: 'hgranger').hours).to eq(8)
       expect(ComEffort.find_by(com_id: 'hgranger').event_type).to eq('Sm Grp Facilitation')
       expect(ComEffort.find_by(com_id: 'hgranger').event).to eq('FTF REQ Various Rooms 10-12 PBL - EndoRepro PBL 1402 - Thyroid')
+      expect(ComEffort.find_by(com_id: 'hgranger').event_date).to eq('11/1/2001')
       expect(ComEffort.find_by(com_id: 'lskywalker').hours).to eq(6.5)
       expect(ComEffort.find_by(com_id: 'lskywalker').event_type).to eq('Lecture')
       expect(ComEffort.find_by(com_id: 'lskywalker').faculty).to eq(faculty2)

--- a/spec/importers/com_data/com_effort_xml_builder_spec.rb
+++ b/spec/importers/com_data/com_effort_xml_builder_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ComData::ComEffortXmlBuilder do
        'COURSE_YEAR' => '1976-1977',
        'EVENT_TYPE' => 'Lecture',
        'EVENT' => 'FTF REQ Various Rooms 10-12 PBL - EndoRepro PBL 1402 - Thyroid',
-       'EVENT_DATE' => '5/25/77',
+       'EVENT_DATE' => '5/25/1977',
        'UME_CALCULATED_TEACHING_WHILE_NON_BILLING_EFFORT__HRS_' => 2.5 },
      { 'FACULTY_USERNAME' => 'hgranger',
        'FACULTY_NAME' => 'Granger Hermione',
@@ -16,7 +16,7 @@ RSpec.describe ComData::ComEffortXmlBuilder do
        'COURSE_YEAR' => '2022-2023',
        'EVENT_TYPE' => 'Sm Grp Facilitation',
        'EVENT' => 'FTF REQ Various Rooms 10-12 PBL - EndoRepro PBL 1402 - Thyroid',
-       'EVENT_DATE' => '6/26/23',
+       'EVENT_DATE' => '6/26/2023',
        'UME_CALCULATED_TEACHING_WHILE_NON_BILLING_EFFORT__HRS_' => 7.25 },
      { 'FACULTY_USERNAME' => 'notCOM',
        'FACULTY_NAME' => 'Not MD',
@@ -24,7 +24,7 @@ RSpec.describe ComData::ComEffortXmlBuilder do
        'COURSE_YEAR' => '2022-2023',
        'EVENT_TYPE' => 'Lacture',
        'EVENT' => 'Test Event for employee not in College of Medicine',
-       'EVENT_DATE' => '1/1/23',
+       'EVENT_DATE' => '1/1/2023',
        'UME_CALCULATED_TEACHING_WHILE_NON_BILLING_EFFORT__HRS_' => 1 }]
   end
 


### PR DESCRIPTION
This integration was not parsing dates properly.  It was taking "9/5/2024  11:00:00 AM" date format and converting it to "Sat, 05 Sep 2020" – not parsing the year correctly.  Not sure if this issue arose because the date format changed in the CSV we import, or because recent ruby upgrades don't handle "2024" and "24" the same as older versions.