### PR TITLE
Add APP_NAME parameter to deployment jobs and simplify image release …

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,6 +179,7 @@ jobs:
       CONFIG_REPO_NAME: << pipeline.parameters.CONFIG_REPO_NAME >>
       CONFIG_REPO_URL: << pipeline.parameters.CONFIG_REPO_URL >>
       DELETE_BRANCH: << parameters.delete_branch >>
+      APP_NAME: "fams-tools"
     steps:
       - clone-config-repo
       - run:
@@ -198,6 +199,7 @@ jobs:
       CONFIG_REPO_NAME: << pipeline.parameters.CONFIG_REPO_NAME >>
       CONFIG_REPO_URL: << pipeline.parameters.CONFIG_REPO_URL >>
       CONFIG_REPO: << pipeline.parameters.CONFIG_REPO_URL >>
+      APP_NAME: "fams-tools"
     parameters:
       clusters:
         type: string
@@ -248,11 +250,7 @@ jobs:
       - run:
           name: Tag & Release Image
           command: |
-            export TRIGGERED_BY="$CIRCLE_USERNAME"
-            /usr/local/bin/image-tag
-            cd $CONFIG_REPO_NAME
-            /usr/local/bin/image-release-pr "clusters/prod/manifests/fams_tools/prod.yaml"
-            /usr/local/bin/image-release-pr "clusters/ulprod/manifests/fams_tools/prod.yaml"
+            /usr/local/bin/image-release-for-clusters
 
 workflows:
 


### PR DESCRIPTION
This pull request updates the `.circleci/config.yml` file to streamline the image tagging and release process for the `fams-tools` application. The main changes involve setting the `APP_NAME` environment variable explicitly and replacing manual release steps with a new script for handling image releases across clusters.

**CircleCI Job Configuration:**

- Explicitly sets the `APP_NAME` environment variable to `"fams-tools"` in relevant jobs, ensuring consistent application identification throughout the CI/CD pipeline. [[1]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R182) [[2]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R202)

**Image Release Process:**

- Simplifies and centralizes the image release workflow by replacing multiple manual commands with a single `/usr/local/bin/image-release-for-clusters` script, reducing complexity and potential errors in the deployment process.…command