### PR TITLE
Feature/etda month to month window v2

### DIFF
--- a/app/importers/committee_data/etda_importer.rb
+++ b/app/importers/committee_data/etda_importer.rb
@@ -4,9 +4,10 @@ module CommitteeData
   class EtdaImporter
     class DegreeTypeError < RuntimeError; end
 
-    def import_all(since: 30.days.ago)
+    def import_all(since: Date.current.prev_month.change(day: 10),
+                   until_date: Date.current.change(day: 10))
       Faculty.find_each do |faculty|
-        import_for_faculty(faculty, since:)
+        import_for_faculty(faculty, since:, until_date:)
       rescue StandardError => e
         Rails.logger.error("Failed to import committees for #{faculty.access_id}: #{e.message}")
       end
@@ -14,11 +15,11 @@ module CommitteeData
 
     private
 
-    def import_for_faculty(faculty, since:)
+    def import_for_faculty(faculty, since:, until_date:)
       total = 0
       Endpoint.each do |endpoint|
         endpoint_result = fetch_from_endpoint(faculty.access_id, endpoint)
-        total += process_endpoint_result(faculty, endpoint.partner, endpoint_result, since:)
+        total += process_endpoint_result(faculty, endpoint.partner, endpoint_result, since:, until_date:)
       end
       Rails.logger.info("Saved #{total} committees for #{faculty.access_id}")
     end
@@ -31,7 +32,7 @@ module CommitteeData
       { success: false, error: e.message }
     end
 
-    def process_endpoint_result(faculty, endpoint_name, endpoint_result, since:)
+    def process_endpoint_result(faculty, endpoint_name, endpoint_result, since:, until_date:)
       unless endpoint_result[:success]
         Rails.logger.error("Failed to fetch from #{endpoint_name} for #{faculty.access_id}: #{endpoint_result[:error]}")
         return 0
@@ -41,7 +42,7 @@ module CommitteeData
       saved = 0
 
       committees_data.each do |committee_data|
-        next unless within_import_window?(committee_data['approval_started_at'], since:)
+        next unless within_import_window?(committee_data['approval_started_at'], since:, until_date:)
 
         role, role_other = CommitteeRoleNormalizer.normalize(committee_data['role'])
         type_of_work = map_type_of_work(committee_data['degree_type'])
@@ -111,10 +112,10 @@ module CommitteeData
       nil
     end
 
-    def within_import_window?(date_string, since:)
+    def within_import_window?(date_string, since:, until_date:)
       return false if date_string.blank?
 
-      Date.parse(date_string) >= since.to_date
+      Date.parse(date_string).between?(since.to_date, until_date.to_date)
     rescue ArgumentError
       false
     end

--- a/app/jobs/activity_insight_committee_job.rb
+++ b/app/jobs/activity_insight_committee_job.rb
@@ -1,20 +1,17 @@
 class ActivityInsightCommitteeJob < ApplicationJob
-  def integrate(target, since: nil)
-    window_since, window_until = since ? [since, since.next_month] : default_window
-    CommitteeData::EtdaImporter.new.import_all(since: window_since, until_date: window_until)
+  def integrate(target, month_range: 1)
+    since_date  = month_range.months.ago.to_date.change(day: 10)
+    until_date  = Date.current.change(day: 10)
+    CommitteeData::EtdaImporter.new.import_all(since: since_date, until_date:)
 
-    builder   = CommitteeData::CommitteeXmlBuilder.new
-    xml_enum  = builder.xmls_enumerator
+    builder    = CommitteeData::CommitteeXmlBuilder.new
+    xml_enum   = builder.xmls_enumerator
 
     integrator = ActivityInsight::IntegrateData.new(xml_enum, target, :post)
     integrator.integrate
   end
 
   private
-
-  def default_window
-    [Date.current.prev_month.change(day: 10), Date.current.change(day: 10)]
-  end
 
   def name
     'Committee Integration'

--- a/app/jobs/activity_insight_committee_job.rb
+++ b/app/jobs/activity_insight_committee_job.rb
@@ -1,6 +1,7 @@
 class ActivityInsightCommitteeJob < ApplicationJob
-  def integrate(target)
-    CommitteeData::EtdaImporter.new.import_all
+  def integrate(target, since: nil)
+    window_since, window_until = since ? [since, since.next_month] : default_window
+    CommitteeData::EtdaImporter.new.import_all(since: window_since, until_date: window_until)
 
     builder   = CommitteeData::CommitteeXmlBuilder.new
     xml_enum  = builder.xmls_enumerator
@@ -10,6 +11,10 @@ class ActivityInsightCommitteeJob < ApplicationJob
   end
 
   private
+
+  def default_window
+    [Date.current.prev_month.change(day: 10), Date.current.change(day: 10)]
+  end
 
   def name
     'Committee Integration'

--- a/lib/tasks/committee.rake
+++ b/lib/tasks/committee.rake
@@ -1,7 +1,8 @@
 namespace :committee do
   desc 'Import committee data from ETDA and integrate with Activity Insight'
-  task :integrate, [:target] => :environment do |_task, args|
+  task :integrate, %i[target since] => :environment do |_task, args|
     target = args[:target].blank? ? :production : args[:target].to_sym
-    ActivityInsightCommitteeJob.new.integrate(target)
+    since  = args[:since].present? ? Date.parse(args[:since]) : nil
+    ActivityInsightCommitteeJob.new.integrate(target, since: since)
   end
 end

--- a/lib/tasks/committee.rake
+++ b/lib/tasks/committee.rake
@@ -1,8 +1,8 @@
 namespace :committee do
   desc 'Import committee data from ETDA and integrate with Activity Insight'
-  task :integrate, %i[target since] => :environment do |_task, args|
-    target = args[:target].blank? ? :production : args[:target].to_sym
-    since  = args[:since].present? ? Date.parse(args[:since]) : nil
-    ActivityInsightCommitteeJob.new.integrate(target, since: since)
+  task :integrate, %i[target month_range] => :environment do |_task, args|
+    target      = args[:target].blank? ? :production : args[:target].to_sym
+    month_range = args[:month_range].present? ? args[:month_range].to_i : 1
+    ActivityInsightCommitteeJob.new.integrate(target, month_range: month_range)
   end
 end

--- a/spec/importers/committee_data/etda_importer_spec.rb
+++ b/spec/importers/committee_data/etda_importer_spec.rb
@@ -175,23 +175,24 @@ RSpec.describe CommitteeData::EtdaImporter do
 
   describe '#within_import_window?' do
     let(:since) { 30.days.ago }
+    let(:until_date) { Time.current }
 
     it 'returns true for a date within the import window' do
       recent_date = 1.week.ago.iso8601
-      expect(importer.send(:within_import_window?, recent_date, since: since)).to be true
+      expect(importer.send(:within_import_window?, recent_date, since: since, until_date: until_date)).to be true
     end
 
     it 'returns false for a date older than the import window' do
       old_date = 1.year.ago.iso8601
-      expect(importer.send(:within_import_window?, old_date, since: since)).to be false
+      expect(importer.send(:within_import_window?, old_date, since: since, until_date: until_date)).to be false
     end
 
     it 'returns false for a nil date' do
-      expect(importer.send(:within_import_window?, nil, since: since)).to be false
+      expect(importer.send(:within_import_window?, nil, since: since, until_date: until_date)).to be false
     end
 
     it 'returns false for a blank date' do
-      expect(importer.send(:within_import_window?, '', since: since)).to be false
+      expect(importer.send(:within_import_window?, '', since: since, until_date: until_date)).to be false
     end
   end
 

--- a/spec/jobs/activity_insight_committee_job_spec.rb
+++ b/spec/jobs/activity_insight_committee_job_spec.rb
@@ -19,7 +19,15 @@ RSpec.describe ActivityInsightCommitteeJob, type: :job do
       )
     end
 
+    let(:importer_double) do
+      instance_double(CommitteeData::EtdaImporter, import_all: nil)
+    end
+
     before do
+      allow(CommitteeData::EtdaImporter)
+        .to receive(:new)
+        .and_return(importer_double)
+
       allow(CommitteeData::CommitteeXmlBuilder)
         .to receive(:new)
         .and_return(builder_double)
@@ -47,6 +55,38 @@ RSpec.describe ActivityInsightCommitteeJob, type: :job do
       expect(integrator_double).to receive(:integrate)
       result = described_class.new.integrate(target)
       expect(result).to eq([])
+    end
+
+    describe 'window computation' do
+      let(:current_date) { Date.new(2026, 6, 18) }
+
+      before do
+        allow(Date).to receive(:current).and_return(current_date)
+      end
+
+      it 'defaults to 1 month back (May 10 → June 10)' do
+        expect(importer_double).to receive(:import_all).with(
+          since: Date.new(2026, 5, 10),
+          until_date: Date.new(2026, 6, 10)
+        )
+        described_class.new.integrate(target)
+      end
+
+      it 'with month_range: 3 fetches from March 10 → June 10' do
+        expect(importer_double).to receive(:import_all).with(
+          since: Date.new(2026, 3, 10),
+          until_date: Date.new(2026, 6, 10)
+        )
+        described_class.new.integrate(target, month_range: 3)
+      end
+
+      it 'with month_range: 6 fetches from December 10 2025 → June 10 2026' do
+        expect(importer_double).to receive(:import_all).with(
+          since: Date.new(2025, 12, 10),
+          until_date: Date.new(2026, 6, 10)
+        )
+        described_class.new.integrate(target, month_range: 6)
+      end
     end
   end
 


### PR DESCRIPTION
Replace the rolling 30-day import window with a precise 10th-to-10th monthly range. The importer now accepts explicit since/until_date bounds defaulting to the 10th of the previous month through the 10th of the current month. The rake task and job are updated to support passing a custom since date for backfill runs.