### PR TITLE
Hotfix: Allow 'Pending' contracts to update to anything, but don't allow new 'Purged' or 'Withdrawn' contracts to import

### DIFF
--- a/app/importers/osp_data/osp_importer.rb
+++ b/app/importers/osp_data/osp_importer.rb
@@ -1,11 +1,11 @@
 class OspData::OspImporter
-  attr_accessor :headers, :csv_obj, :pendnotfund
+  attr_accessor :headers, :csv_obj, :pending_osps
 
   def initialize(osp_path = "#{Rails.root.join('app/parsing_files/contract_grants.csv')}",
                  backup_path = "#{Rails.root.join('app/parsing_files/CONGRANT.csv')}")
     @csv_obj = CSV.open(osp_path, encoding: 'Windows-1252:UTF-8', force_quotes: true, quote_char: '"')
     @headers = @csv_obj.first
-    @pendnotfund = find_converts(backup_path)
+    @pending_osps = find_converts(backup_path)
   end
 
   # Run all local formatting methods then import to db
@@ -54,15 +54,16 @@ class OspData::OspImporter
     false
   end
 
-  # We want to update Not Funded to purged or withdrawn but we dont want to import any new Not Funded, withdrawn, or purged contracts
+  # We want to update 'Pending' contracts when their status changes to anything 
+  # (including but not limited to 'Purged', 'Withdrawn', and 'Not Funded'), 
+  # but we don't want to import any _new_ 'Withdrawn' or 'Purged' contracts.
   def is_proper_status(row)
     if %w[Purged Withdrawn].include?(row['status'])
-      return true if pendnotfund.include? row['ospkey']
+      return true if pending_osps.include? row['ospkey']
 
       false
-
     else
-      ['Not Funded'].exclude?(row['status'])
+      true
     end
   end
 
@@ -130,18 +131,18 @@ DateTime.strptime(row['accessid'],
   def find_converts(backup_path)
     index = 0
     keys = []
-    pendnotfund = []
+    pending_osps = []
     CSV.foreach(backup_path, encoding: 'ISO8859-1:UTF-8', force_quotes: true, quote_char: '"',
                              liberal_parsing: true) do |backup_row|
       if index == 0
         keys = backup_row
       else
         hashed = keys.zip(backup_row).to_h
-        pendnotfund << hashed['OSPKEY'] if ['Pending', 'Not Funded'].include?(hashed['STATUS'])
+        pending_osps << hashed['OSPKEY'] if ['Pending'].include?(hashed['STATUS'])
       end
       index += 1
     end
-    pendnotfund
+    pending_osps
   end
 
   def format_titles(row)

--- a/app/importers/osp_data/osp_importer.rb
+++ b/app/importers/osp_data/osp_importer.rb
@@ -54,8 +54,8 @@ class OspData::OspImporter
     false
   end
 
-  # We want to update 'Pending' contracts when their status changes to anything 
-  # (including but not limited to 'Purged', 'Withdrawn', and 'Not Funded'), 
+  # We want to update 'Pending' contracts when their status changes to anything
+  # (including but not limited to 'Purged', 'Withdrawn', and 'Not Funded'),
   # but we don't want to import any _new_ 'Withdrawn' or 'Purged' contracts.
   def is_proper_status(row)
     if %w[Purged Withdrawn].include?(row['status'])

--- a/spec/importers/osp_data/osp_importer_spec.rb
+++ b/spec/importers/osp_data/osp_importer_spec.rb
@@ -89,6 +89,8 @@ RSpec.describe OspData::OspImporter do
                  0.15, 0.15, 0.15]
     data_arr << [2, 1, '', '', '', '', '', '', '', 1, 'Awarded', '', '', 1, 1, 1, '', '', '', '', '', '', '', '', '',
                  0.15, 0.15, 0.15]
+    data_arr << [193_848, 1, '', '', '', '', '', '', '', 1, 'Purged', '', '', 1, 1, 1, '', '', '', '', '', '', '', '',
+                 '', 0.15, 0.15, 0.15]
     data_arr
   end
 
@@ -96,7 +98,7 @@ RSpec.describe OspData::OspImporter do
     data_arr = []
     data_arr << %w[OSPKEY STATUS]
     data_arr << [123_456, 'Pending']
-    data_arr << [193_848, 'Not Funded']
+    data_arr << [193_848, 'Pending']
   end
 
   before do
@@ -179,8 +181,8 @@ RSpec.describe OspData::OspImporter do
     end
   end
 
-  describe '#filter_by_status' do
-    it "removes rows with 'Purged' or 'Withdrawn' status" do
+  describe '#is_proper_status' do
+    it "keeps 'Purged' or 'Withdrawn' rows only when the record was previously 'Pending'" do
       allow(CSV).to receive(:open).and_return(data_book4)
       allow(CSV).to receive(:foreach).and_yield(fake_backup[0]).and_yield(fake_backup[1]).and_yield(fake_backup[2])
       allow_any_instance_of(OspData::OspImporter).to receive(:is_good_date).and_return(true)
@@ -189,17 +191,18 @@ RSpec.describe OspData::OspImporter do
       expect(Contract.count).to eq(3)
       expect(Contract.first.status).to eq('Awarded')
       expect(Contract.second.status).to eq('Withdrawn')
+      expect(Contract.second.osp_key).to eq(123_456)
       expect(Contract.third.status).to eq('Purged')
+      expect(Contract.third.osp_key).to eq(193_848)
     end
 
-    it "removes rows with 'Not Funded' status" do
+    it "keeps rows with 'Not Funded' status (and any other status that is not 'Purged' or 'Withdrawn')" do
       allow(CSV).to receive(:open).and_return(data_book6)
-      allow(CSV).to receive(:foreach).and_yield(fake_backup[0]).and_yield(fake_backup[1]).and_yield(fake_backup[2])
       allow_any_instance_of(OspData::OspImporter).to receive(:is_good_date).and_return(true)
       allow_any_instance_of(OspData::OspImporter).to receive(:is_user).and_return(true)
       osp_parser_obj.format_and_populate
-      expect(Contract.count).to eq(1)
-      expect(Contract.first.status).to eq('Awarded')
+      expect(Contract.count).to eq(2)
+      expect(Contract.pluck(:status)).to contain_exactly('Not Funded', 'Awarded')
     end
   end
 

--- a/spec/jobs/activity_insight_committee_job_spec.rb
+++ b/spec/jobs/activity_insight_committee_job_spec.rb
@@ -62,9 +62,7 @@ RSpec.describe ActivityInsightCommitteeJob, type: :job do
     describe 'window computation' do
       let(:current_date) { Date.new(2026, 6, 18) }
 
-      around do |example|
-        travel_to(current_date) { example.run }
-      end
+      before { travel_to(current_date) }
 
       it 'defaults to 1 month back (May 10 → June 10)' do
         expect(importer_double).to receive(:import_all).with(

--- a/spec/jobs/activity_insight_committee_job_spec.rb
+++ b/spec/jobs/activity_insight_committee_job_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe ActivityInsightCommitteeJob, type: :job do
+  include ActiveSupport::Testing::TimeHelpers
+
   describe '#integrate' do
     let(:target) { 'test_target' }
     let(:xml_enumerator) { ['<xml>test</xml>'].to_enum }
@@ -60,8 +62,8 @@ RSpec.describe ActivityInsightCommitteeJob, type: :job do
     describe 'window computation' do
       let(:current_date) { Date.new(2026, 6, 18) }
 
-      before do
-        allow(Date).to receive(:current).and_return(current_date)
+      around do |example|
+        travel_to(current_date) { example.run }
       end
 
       it 'defaults to 1 month back (May 10 → June 10)' do


### PR DESCRIPTION
Updated logic from some of the changes in #133 and #164 

Background: We noticed 'Pending' contracts were not updating to 'Not Funded' when changed in the SIMs system.